### PR TITLE
Update requirements for Ubuntu/Debian about mariadb installion

### DIFF
--- a/Quick-Start-Guide.md
+++ b/Quick-Start-Guide.md
@@ -2,7 +2,7 @@
 
 <details>
   <summary>Windows 10</summary>
-  
+
   ## To Install
   * Install [Git for Windows](https://gitforwindows.org/), accept defaults, change default text editor if desired.
   * Install [Visual Studio 2019](https://visualstudio.microsoft.com/vs/community/), check Desktop development with C++.
@@ -49,13 +49,16 @@
 
 <details>
   <summary>Linux (Debian/Ubuntu)</summary>
-  
+
   ## To Install
   * Use your package manager to install the following packages or their equivalent:
 
     <details>
       <summary>Debian/Ubuntu</summary>
 
+      Run these steps to use Mariadb's community provided .deb packages through apt:
+
+      https://mariadb.com/docs/connect/programming-languages/c/install/#connector-c-install-repo-configure-cs
       ```
       sudo apt update
       sudo apt install git python3 python3-pip g++-10 cmake make libluajit-5.1-dev libzmq3-dev libssl-dev zlib1g-dev mariadb-server libmariadb-dev binutils-dev
@@ -139,9 +142,9 @@ _These platforms should work but are not actively maintained or used by the deve
 
 <details>
   <summary>OSX</summary>
-  
+
 ## To Install
-  
+
 * Get dependencies from brew:
 
 ```
@@ -187,7 +190,7 @@ cmake .. -DLuaJIT_INCLUDE_DIR=<SERVER_ROOT>/server/ext/lua/include
 
 <details>
   <summary>Linux (through WSL)</summary>
-  
+
 [Working with WSL](Working-with-WSL)
 </details>
 

--- a/Server-Setup-and-Maintenance-Linux.md
+++ b/Server-Setup-and-Maintenance-Linux.md
@@ -1,7 +1,7 @@
 ##### Table of Contents  
-- [Install](#install)  
-- [Update](#update)  
-- [Miscellaneous](#miscellaneous)  
+- [Install](#install)
+- [Update](#update)
+- [Miscellaneous](#miscellaneous)
 
 # Install
 
@@ -11,7 +11,10 @@ Installs requirements to run the sql database and tools to compile the source co
 
 <details>
   <summary>Debian/Ubuntu</summary>
+ 
+Run these steps to use Mariadb's community provided .deb packages through apt:
 
+https://mariadb.com/docs/connect/programming-languages/c/install/#connector-c-install-repo-configure-cs
 ```
 sudo apt update
 sudo apt install git python3 python3-pip g++-9 cmake make libluajit-5.1-dev libzmq3-dev libssl-dev zlib1g-dev mariadb-server libmariadb-dev binutils-dev


### PR DESCRIPTION
See title, just updating the docs about how to de-facto use ubuntu with mariadb due to pip3 needing a newer mariadb installed