### PR TITLE
Remove deprecated keyitems require from script examples

### DIFF
--- a/Full-Battlefield-Example.md
+++ b/Full-Battlefield-Example.md
@@ -7,7 +7,6 @@
 -----------------------------------
 local ID = require("scripts/zones/Bearclaw_Pinnacle/IDs")
 require("scripts/globals/battlefield")
-require("scripts/globals/keyitems")
 require("scripts/globals/zone")
 -----------------------------------
 

--- a/Full-Quest-Example.md
+++ b/Full-Quest-Example.md
@@ -6,7 +6,6 @@
 -----------------------------------
 require("scripts/globals/interaction/quest")
 require("scripts/globals/weaponskillids")
-require("scripts/globals/keyitems")
 require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/items")


### PR DESCRIPTION
Removes requires no longer necessary from script examples with keyitems moving to scripts/enum